### PR TITLE
Add CLI runner package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "k8s-script-runner"
+version = "0.1.0"
+description = "CLI tool for running Kubernetes scripts."
+readme = "README.md"
+requires-python = ">=3.8"
+authors = [{name = "Your Name", email = "you@example.com"}]
+license = {file = "LICENSE"}
+
+[project.scripts]
+k8s-script-runner = "runner.cli:main"

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -1,0 +1,6 @@
+"""Runner package."""
+
+__all__ = ["main"]
+
+from .cli import main
+

--- a/runner/cli.py
+++ b/runner/cli.py
@@ -1,0 +1,11 @@
+"""Command line interface for k8s script runner."""
+
+import click
+
+@click.command()
+def main() -> None:
+    """Entry point for the k8s script runner CLI."""
+    click.echo("k8s-script-runner invoked")
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,18 @@
+"""Tests for the k8s script runner CLI."""
+
+from click.testing import CliRunner
+
+# Ensure the parent directory is on the Python path so ``runner`` can be imported
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from runner.cli import main
+
+
+def test_help():
+    """Ensure the help command exits with code 0."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["--help"])
+    assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- add a basic `runner` CLI using click
- publish `k8s-script-runner` entry point via `pyproject.toml`
- provide tests for the CLI help output

## Testing
- `pytest -q`
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0)*

------
https://chatgpt.com/codex/tasks/task_e_685fc0fc6a048333a9945b0863278145