### PR TITLE
Add run subcommand with verbose option

### DIFF
--- a/runner/cli.py
+++ b/runner/cli.py
@@ -1,11 +1,52 @@
 """Command line interface for k8s script runner."""
 
+from __future__ import annotations
+
+import sys
+import logging
+from typing import Optional
+
 import click
 
-@click.command()
-def main() -> None:
-    """Entry point for the k8s script runner CLI."""
-    click.echo("k8s-script-runner invoked")
+try:
+    from loguru import logger  # type: ignore
 
-if __name__ == "__main__":
+    LOGURU_AVAILABLE = True
+except Exception:  # pragma: no cover - fallback if loguru is missing
+    LOGURU_AVAILABLE = False
+    logger = logging.getLogger("runner")
+
+
+@click.group()
+@click.option("--verbose", is_flag=True, help="Enable debug output.")
+@click.pass_context
+def main(ctx: click.Context, verbose: bool) -> None:
+    """Entry point for the k8s script runner CLI."""
+    if LOGURU_AVAILABLE:
+        if verbose:
+            logger.remove()  # type: ignore[operator]
+            logger.add(sys.stderr, level="DEBUG")  # type: ignore[call-arg]
+    else:
+        logger.setLevel(logging.DEBUG if verbose else logging.INFO)
+        logger.handlers.clear()
+        handler = logging.StreamHandler(sys.stderr)
+        formatter = logging.Formatter("%(levelname)s:%(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+
+@main.command()
+@click.option("--script-file", type=click.Path(), required=False)
+@click.option("--query-file", type=click.Path(), required=False)
+def run(script_file: Optional[str], query_file: Optional[str]) -> None:
+    """Run a script or query."""
+    if not script_file and not query_file:
+        raise click.UsageError(
+            "At least one of --script-file or --query-file is required."
+        )
+    logger.debug("Running command")
+    click.echo("run invoked")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
     main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,3 +16,42 @@ def test_help():
     runner = CliRunner()
     result = runner.invoke(main, ["--help"])
     assert result.exit_code == 0
+
+
+def test_run_script_file():
+    """Running with only --script-file succeeds."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["run", "--script-file", "foo"])
+    assert result.exit_code == 0
+
+
+def test_run_query_file():
+    """Running with only --query-file succeeds."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["run", "--query-file", "bar"])
+    assert result.exit_code == 0
+
+
+def test_run_both_files():
+    """Running with both options succeeds."""
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        ["run", "--script-file", "foo", "--query-file", "bar"],
+    )
+    assert result.exit_code == 0
+
+
+def test_run_missing_options():
+    """Fail when no options are provided."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["run"])
+    assert result.exit_code != 0
+
+
+def test_verbose_outputs_debug():
+    """Verbose flag triggers debug output."""
+    runner = CliRunner()
+    result = runner.invoke(main, ["--verbose", "run", "--script-file", "foo"])
+    assert result.exit_code == 0
+    assert "Running command" in result.output


### PR DESCRIPTION
## Summary
- add `run` command with `--script-file` and `--query-file`
- add global `--verbose` option to enable DEBUG logging
- validate options so at least one of script or query is given
- test help, valid/invalid combinations and verbose output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fc2036c188333bfe343eff6150c21