### PR TITLE
Add k8s utilities and integration test

### DIFF
--- a/runner/k8s.py
+++ b/runner/k8s.py
@@ -1,0 +1,122 @@
+"""Helper functions for interacting with Kubernetes pods."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from kubernetes import client, config
+from kubernetes.stream import stream
+
+
+class RunnerTimeoutError(RuntimeError):
+    """Raised when a Kubernetes operation exceeds the given timeout."""
+
+
+def ensure_context(context: Optional[str] = None) -> client.CoreV1Api:
+    """Load Kubernetes configuration and return a CoreV1Api instance."""
+    try:
+        config.load_kube_config(context=context)
+    except config.ConfigException:
+        config.load_incluster_config()
+    return client.CoreV1Api()
+
+
+def exec_in_pod(
+    api: client.CoreV1Api,
+    namespace: str,
+    pod: str,
+    command: Iterable[str],
+    *,
+    container: Optional[str] = None,
+    timeout: int | float | None = None,
+) -> str:
+    """Execute a command in the specified pod and return stdout."""
+    try:
+        return stream(
+            api.connect_get_namespaced_pod_exec,
+            pod,
+            namespace,
+            command=list(command),
+            container=container,
+            stderr=True,
+            stdin=False,
+            stdout=True,
+            tty=False,
+            _request_timeout=timeout,
+        )
+    except Exception as exc:  # pragma: no cover - passthrough for API errors
+        if "timed out" in str(exc).lower():
+            raise RunnerTimeoutError(str(exc)) from exc
+        raise
+
+
+def copy_file_to_pod(
+    api: client.CoreV1Api,
+    src: Path,
+    namespace: str,
+    pod: str,
+    dest: str,
+    *,
+    container: Optional[str] = None,
+    timeout: int | float | None = None,
+) -> None:
+    """Copy a local file into the pod."""
+    data = src.read_bytes()
+    encoded = base64.b64encode(data).decode()
+    command = ["/bin/sh", "-c", f"base64 -d > {dest}"]
+    try:
+        resp = stream(
+            api.connect_get_namespaced_pod_exec,
+            pod,
+            namespace,
+            command=command,
+            container=container,
+            stderr=True,
+            stdin=True,
+            stdout=True,
+            tty=False,
+            _preload_content=False,
+            _request_timeout=timeout,
+        )
+        resp.write_stdin(encoded)
+        resp.close()
+    except Exception as exc:  # pragma: no cover - passthrough for API errors
+        if "timed out" in str(exc).lower():
+            raise RunnerTimeoutError(str(exc)) from exc
+        raise
+
+
+def copy_from_pod(
+    api: client.CoreV1Api,
+    namespace: str,
+    pod: str,
+    src: str,
+    dest: Path,
+    *,
+    container: Optional[str] = None,
+    timeout: int | float | None = None,
+) -> None:
+    """Copy a file from the pod to the local filesystem."""
+    command = ["/bin/sh", "-c", f"base64 {src}"]
+    try:
+        encoded = stream(
+            api.connect_get_namespaced_pod_exec,
+            pod,
+            namespace,
+            command=command,
+            container=container,
+            stderr=True,
+            stdin=False,
+            stdout=True,
+            tty=False,
+            _request_timeout=timeout,
+        )
+    except Exception as exc:  # pragma: no cover - passthrough for API errors
+        if "timed out" in str(exc).lower():
+            raise RunnerTimeoutError(str(exc)) from exc
+        raise
+    data = base64.b64decode(encoded)
+    dest.write_bytes(data)
+

--- a/tests/test_k8s_integration.py
+++ b/tests/test_k8s_integration.py
@@ -1,0 +1,63 @@
+"""Integration tests for Kubernetes helper functions."""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+# Ensure the parent directory is on the Python path so ``runner`` can be imported
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+import pytest
+
+pytest.importorskip("kubernetes", reason="kubernetes package required")
+from kubernetes import client, config
+
+from runner.k8s import copy_file_to_pod, copy_from_pod, ensure_context, exec_in_pod
+
+
+@pytest.mark.skipif(os.environ.get("CI") == "true", reason="kind not available in CI")
+def test_copy_and_exec(tmp_path: Path) -> None:
+    """Create a kind cluster and verify copy/exec helpers."""
+    if shutil.which("kind") is None:
+        pytest.skip("kind binary not found")
+    if shutil.which("kubectl") is None:
+        pytest.skip("kubectl binary not found")
+
+    cluster_name = "runner-test"
+    subprocess.run(["kind", "create", "cluster", "--name", cluster_name], check=True)
+    try:
+        api = ensure_context(f"kind-{cluster_name}")
+        pod_manifest = {
+            "apiVersion": "v1",
+            "kind": "Pod",
+            "metadata": {"name": "helper"},
+            "spec": {
+                "containers": [
+                    {"name": "bb", "image": "busybox", "command": ["sleep", "3600"]}
+                ],
+                "restartPolicy": "Never",
+            },
+        }
+        api.create_namespaced_pod(namespace="default", body=pod_manifest)
+        for _ in range(60):
+            pod = api.read_namespaced_pod("helper", "default")
+            if pod.status.phase == "Running":
+                break
+            time.sleep(1)
+        else:
+            raise RuntimeError("pod did not start")
+
+        local_file = tmp_path / "foo.txt"
+        local_file.write_text("hello")
+        copy_file_to_pod(api, local_file, "default", "helper", "/tmp/foo.txt")
+        assert exec_in_pod(api, "default", "helper", ["echo", "ok"]).strip() == "ok"
+        out_file = tmp_path / "bar.txt"
+        copy_from_pod(api, "default", "helper", "/tmp/foo.txt", out_file)
+        assert out_file.read_text() == "hello"
+    finally:
+        subprocess.run(["kind", "delete", "cluster", "--name", cluster_name], check=False)
+


### PR DESCRIPTION
## Summary
- create `runner.k8s` with helper functions using Kubernetes client
- add integration test that exercises copy/exec helpers against a kind cluster

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fc37308888333b2417bd2387e12c3