### PR TITLE
Add command mapping and CLI execution

### DIFF
--- a/runner/exec_map.py
+++ b/runner/exec_map.py
@@ -1,0 +1,47 @@
+"""Utility for mapping script filenames to execution commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+
+class UnsupportedScriptError(Exception):
+    """Raised when a script has an unrecognized file extension."""
+
+
+_COMMAND_MAP = {
+    ".py": ["python3"],
+    ".sh": ["/bin/sh"],
+    ".go": ["go", "run"],
+    ".mongo": ["mongosh"],
+    ".js": ["mongosh"],
+}
+
+
+def command_for_file(path: Path) -> List[str]:
+    """Return the command required to execute ``path``.
+
+    Parameters
+    ----------
+    path:
+        The script file whose interpreter should be determined.
+
+    Returns
+    -------
+    List[str]
+        The command (as a list suitable for :func:`subprocess.run`) to execute
+        the provided file.
+
+    Raises
+    ------
+    UnsupportedScriptError
+        If ``path`` has an extension that is not supported.
+    """
+    ext = path.suffix.lower()
+    if ext not in _COMMAND_MAP:
+        raise UnsupportedScriptError(f"Unsupported script type: {path}")
+    return _COMMAND_MAP[ext] + [str(path)]
+
+
+__all__ = ["UnsupportedScriptError", "command_for_file"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for the k8s script runner CLI."""
 
+from pathlib import Path
 from click.testing import CliRunner
 
 # Ensure the parent directory is on the Python path so ``runner`` can be imported
@@ -11,47 +12,76 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 from runner.cli import main
 
 
-def test_help():
+def test_help() -> None:
     """Ensure the help command exits with code 0."""
     runner = CliRunner()
     result = runner.invoke(main, ["--help"])
     assert result.exit_code == 0
 
 
-def test_run_script_file():
-    """Running with only --script-file succeeds."""
+def test_run_script_file(tmp_path: Path) -> None:
+    """Running with only --script-file executes the given file."""
+    script = tmp_path / "hello.py"
+    script.write_text("print('hello')")
     runner = CliRunner()
-    result = runner.invoke(main, ["run", "--script-file", "foo"])
+    result = runner.invoke(main, ["run", "--script-file", str(script)])
     assert result.exit_code == 0
 
 
-def test_run_query_file():
-    """Running with only --query-file succeeds."""
+def test_run_query_file(tmp_path: Path) -> None:
+    """Running with only --query-file executes the file."""
+    script = tmp_path / "hello.sh"
+    script.write_text("echo hi")
     runner = CliRunner()
-    result = runner.invoke(main, ["run", "--query-file", "bar"])
+    result = runner.invoke(main, ["run", "--query-file", str(script)])
     assert result.exit_code == 0
 
 
-def test_run_both_files():
-    """Running with both options succeeds."""
+def test_run_both_files(tmp_path: Path) -> None:
+    """When both options are given, script-file is preferred."""
+    script = tmp_path / "script.py"
+    script.write_text("print('script')")
+    query = tmp_path / "query.sh"
+    query.write_text("echo query")
     runner = CliRunner()
     result = runner.invoke(
         main,
-        ["run", "--script-file", "foo", "--query-file", "bar"],
+        ["run", "--script-file", str(script), "--query-file", str(query)],
     )
     assert result.exit_code == 0
 
 
-def test_run_missing_options():
+def test_run_missing_options() -> None:
     """Fail when no options are provided."""
     runner = CliRunner()
     result = runner.invoke(main, ["run"])
     assert result.exit_code != 0
 
 
-def test_verbose_outputs_debug():
-    """Verbose flag triggers debug output."""
+def test_exit_status_propagated(tmp_path: Path) -> None:
+    """Non-zero exit codes from scripts are returned by the CLI."""
+    script = tmp_path / "bad.sh"
+    script.write_text("exit 3")
     runner = CliRunner()
-    result = runner.invoke(main, ["--verbose", "run", "--script-file", "foo"])
+    result = runner.invoke(main, ["run", "--script-file", str(script)])
+    assert result.exit_code == 3
+
+
+def test_run_unsupported_extension(tmp_path: Path) -> None:
+    """Unsupported extensions fail with a message."""
+    script = tmp_path / "foo.txt"
+    script.write_text("nothing")
+    runner = CliRunner()
+    result = runner.invoke(main, ["run", "--script-file", str(script)])
+    assert result.exit_code != 0
+    assert "Unsupported script type" in result.output
+
+
+def test_verbose_outputs_debug(tmp_path: Path) -> None:
+    """Verbose flag triggers debug output."""
+    script = tmp_path / "hello.py"
+    script.write_text("print('hi')")
+    runner = CliRunner()
+    result = runner.invoke(main, ["--verbose", "run", "--script-file", str(script)])
     assert result.exit_code == 0
-    assert "Running command" in result.output
+    assert "Executing" in result.output

--- a/tests/test_exec_map.py
+++ b/tests/test_exec_map.py
@@ -1,0 +1,30 @@
+"""Tests for the exec_map module."""
+
+from pathlib import Path
+
+import pytest
+
+from runner.exec_map import command_for_file, UnsupportedScriptError
+
+
+def test_supported_extensions(tmp_path: Path) -> None:
+    """Each supported extension maps to the correct command."""
+    files_and_cmds = {
+        "foo.py": ["python3"],
+        "bar.sh": ["/bin/sh"],
+        "baz.go": ["go", "run"],
+        "qux.mongo": ["mongosh"],
+        "norf.js": ["mongosh"],
+    }
+    for name, cmd in files_and_cmds.items():
+        path = tmp_path / name
+        path.touch()
+        assert command_for_file(path) == cmd + [str(path)]
+
+
+def test_unsupported_extension(tmp_path: Path) -> None:
+    """Unsupported extensions raise an error."""
+    path = tmp_path / "foo.txt"
+    path.touch()
+    with pytest.raises(UnsupportedScriptError):
+        command_for_file(path)


### PR DESCRIPTION
## Summary
- map script extensions to commands in `exec_map`
- use `exec_map` in CLI `run` command and propagate exit statuses
- test supported extensions and CLI run behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fc4ff175c8333a0cebfbb9b4886e7